### PR TITLE
DE11296 MTB fqBeatName update so builds

### DIFF
--- a/beater/pubsubbeat.go
+++ b/beater/pubsubbeat.go
@@ -90,8 +90,7 @@ func New(b *beat.Beat, cfg *common.Config) (beat.Beater, error) {
 	fqBeatName = os.Getenv(environment.FQBeatName)
 
 	logp.Info("Config fields: %+v", config)
-
-	logp.Debug("Fully Qualified Beatname: %s", fqBeatName)
+	logp.Info("Fully Qualified Beatname: %s", fqBeatName)
 
 	bt := &Pubsubbeat{
 		done:         make(chan struct{}),

--- a/beater/pubsubbeat.go
+++ b/beater/pubsubbeat.go
@@ -53,8 +53,11 @@ type Pubsubbeat struct {
 }
 
 const (
-	cycleTime   = 10 //will be in seconds
+	cycleTime = 10 //will be in seconds
+	// ServiceName is the name of the service
 	ServiceName = "pubsubbeat"
+	// FQBeatName variable name for fully qualified beat name
+	FQBeatName = "FullyQualifiedBeatName"
 )
 
 var (
@@ -66,6 +69,7 @@ var (
 
 var stopCh = make(chan struct{})
 
+// New creates an instance of pubsubbeat.
 func New(b *beat.Beat, cfg *common.Config) (beat.Beater, error) {
 	config, err := config.GetAndValidateConfig(cfg)
 	if err != nil {
@@ -93,11 +97,12 @@ func New(b *beat.Beat, cfg *common.Config) (beat.Beater, error) {
 		logger:       logger,
 	}
 
-	fqBeatName = os.Getenv(config.FQBeatName)
+	fqBeatName = os.Getenv(FQBeatName)
 
 	return bt, nil
 }
 
+// Run executes an instance of pubsubbeat.
 func (bt *Pubsubbeat) Run(b *beat.Beat) error {
 
 	bt.logger.Info("pubsubbeat is running! Hit CTRL-C to stop it.")
@@ -203,6 +208,7 @@ func (bt *Pubsubbeat) Run(b *beat.Beat) error {
 	return nil
 }
 
+// Stop a running instance of pubsubbeat.
 func (bt *Pubsubbeat) Stop() {
 	bt.client.Close()
 	close(stopCh)

--- a/beater/pubsubbeat.go
+++ b/beater/pubsubbeat.go
@@ -36,6 +36,7 @@ import (
 
 	"cloud.google.com/go/pubsub"
 	"github.com/logrhythm/pubsubbeat/config"
+	"github.com/logrhythm/pubsubbeat/environment"
 	"github.com/logrhythm/pubsubbeat/heartbeat"
 	"google.golang.org/api/option"
 	"google.golang.org/grpc/codes"
@@ -56,8 +57,6 @@ const (
 	cycleTime = 10 //will be in seconds
 	// ServiceName is the name of the service
 	ServiceName = "pubsubbeat"
-	// FQBeatName variable name for fully qualified beat name
-	FQBeatName = "FullyQualifiedBeatName"
 )
 
 var (
@@ -88,7 +87,12 @@ func New(b *beat.Beat, cfg *common.Config) (beat.Beater, error) {
 	if err != nil {
 		return nil, err
 	}
+	fqBeatName = os.Getenv(environment.FQBeatName)
+
 	logp.Info("Config fields: %+v", config)
+
+	logp.Debug("Fully Qualified Beatname: %s", fqBeatName)
+
 	bt := &Pubsubbeat{
 		done:         make(chan struct{}),
 		config:       config,
@@ -96,8 +100,6 @@ func New(b *beat.Beat, cfg *common.Config) (beat.Beater, error) {
 		subscription: subscription,
 		logger:       logger,
 	}
-
-	fqBeatName = os.Getenv(FQBeatName)
 
 	return bt, nil
 }

--- a/config/config.go
+++ b/config/config.go
@@ -47,8 +47,6 @@ type Config struct {
 	HeartbeatDisabled bool          `config:"heartbeatdisabled"`
 }
 
-var FQBeatName = "FullyQualifiedBeatName"
-
 func GetDefaultConfig() Config {
 	config := Config{}
 	config.Subscription.Create = true

--- a/environment/constants.go
+++ b/environment/constants.go
@@ -1,0 +1,4 @@
+package environment
+
+//FQBeatName is the name of the environment variable containing fully qualified beat name.
+const FQBeatName = "FullyQualifiedBeatName"

--- a/heartbeat/status_beater.go
+++ b/heartbeat/status_beater.go
@@ -9,7 +9,6 @@ import (
 	"github.com/elastic/beats/libbeat/common"
 	"github.com/elastic/beats/libbeat/logp"
 	"github.com/golang/protobuf/ptypes/timestamp"
-	"github.com/logrhythm/pubsubbeat/config"
 )
 
 // Heartbeat is a structure for heartbeat
@@ -31,8 +30,12 @@ const (
 	ServiceRunning = 2
 	//ServiceStopped is a code for stopping a particular service
 	ServiceStopped = 3
+
+	// FQBeatName variable name for fully qualified beat name
+	FQBeatName = "FullyQualifiedBeatName"
 )
 
+// fqBeatName is the fully qualified beat name
 var fqBeatName string
 
 // Status is used for status of heartbeat1
@@ -56,7 +59,7 @@ type StatusBeater struct {
 // Start will begin reporting heartbeats through the beats
 func (sb *StatusBeater) Start(stopChan chan struct{}, publish func(event beat.Event)) {
 	go func() {
-		fqBeatName = os.Getenv(config.FQBeatName)
+		fqBeatName = os.Getenv(FQBeatName)
 		sb.Beat(ServiceStarted, "Service started", publish)
 		for {
 			select {
@@ -105,6 +108,7 @@ func (sb *StatusBeater) PublishEvent(logData []byte, publish func(event beat.Eve
 	}
 	publish(event)
 	logp.Info("heartbeat sent")
+	logp.Debug("Fully Qualified Beatname: %s", fqBeatName)
 }
 
 // NewStatusBeater will return a new StatusBeater with the provided base information

--- a/heartbeat/status_beater.go
+++ b/heartbeat/status_beater.go
@@ -9,6 +9,7 @@ import (
 	"github.com/elastic/beats/libbeat/common"
 	"github.com/elastic/beats/libbeat/logp"
 	"github.com/golang/protobuf/ptypes/timestamp"
+	"github.com/logrhythm/pubsubbeat/environment"
 )
 
 // Heartbeat is a structure for heartbeat
@@ -30,9 +31,6 @@ const (
 	ServiceRunning = 2
 	//ServiceStopped is a code for stopping a particular service
 	ServiceStopped = 3
-
-	// FQBeatName variable name for fully qualified beat name
-	FQBeatName = "FullyQualifiedBeatName"
 )
 
 // fqBeatName is the fully qualified beat name
@@ -59,7 +57,7 @@ type StatusBeater struct {
 // Start will begin reporting heartbeats through the beats
 func (sb *StatusBeater) Start(stopChan chan struct{}, publish func(event beat.Event)) {
 	go func() {
-		fqBeatName = os.Getenv(FQBeatName)
+		fqBeatName = os.Getenv(environment.FQBeatName)
 		sb.Beat(ServiceStarted, "Service started", publish)
 		for {
 			select {
@@ -108,6 +106,8 @@ func (sb *StatusBeater) PublishEvent(logData []byte, publish func(event beat.Eve
 	}
 	publish(event)
 	logp.Info("heartbeat sent")
+
+	// Same log fqBeatName as SIEM ./internal/pkg/heartbeat/status_beater.go func StatusBeater
 	logp.Debug("Fully Qualified Beatname: %s", fqBeatName)
 }
 

--- a/heartbeat/status_beater.go
+++ b/heartbeat/status_beater.go
@@ -106,9 +106,6 @@ func (sb *StatusBeater) PublishEvent(logData []byte, publish func(event beat.Eve
 	}
 	publish(event)
 	logp.Info("heartbeat sent")
-
-	// Same log fqBeatName as SIEM ./internal/pkg/heartbeat/status_beater.go func StatusBeater
-	logp.Debug("Fully Qualified Beatname: %s", fqBeatName)
 }
 
 // NewStatusBeater will return a new StatusBeater with the provided base information


### PR DESCRIPTION
Update MTB fqBeatName variable and usage so pubsubbeat builds
verified build in veracode branch using go.mod and re-generating vendor directory
fqBeatName constant only in environment sub-directory like siem repo
log info fqBeatName at Start Beat (New function)

Do no know if built executable sends MTB tag (fullyqualifiedbeatname) to OC for heartbeat or other messages
When review PR please build pubsubbeat